### PR TITLE
Mark FMUs that are not compliant with the latest rules

### DIFF
--- a/fmus/2.0/me/linux64/solidThinking_Activate/2020/Boocwen/notCompliantWithLatestRules
+++ b/fmus/2.0/me/linux64/solidThinking_Activate/2020/Boocwen/notCompliantWithLatestRules
@@ -1,0 +1,1 @@
+StopTime and reference results don't match

--- a/fmus/2.0/me/win64/solidThinking_Activate/2020/Boocwen/notCompliantWithLatestRules
+++ b/fmus/2.0/me/win64/solidThinking_Activate/2020/Boocwen/notCompliantWithLatestRules
@@ -1,0 +1,1 @@
+StopTime and reference results don't match


### PR DESCRIPTION
This marks FMUs as not compliant that have stop time and reference results that do not match. I've only checked the win64 and linux64 tests.

I am not sure if this is a requirement that was stated explicitly somewhere, but that shouldn't matter anyways.